### PR TITLE
Update README for 'ignore' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Premailer looks for a few CSS attributes that make working with tables a bit eas
 | -premailer-height | Available on `table`, `tr`, `th` and `td` elements |
 | -premailer-cellpadding | Available on `table` elements |
 | -premailer-cellspacing | Available on `table` elements |
-| data-premailer="ignore" | Available on `style` elements. Premailer will ignore these elements entirely. |
+| data-premailer="ignore" | Available on `link` and `style` elements. Premailer will ignore these elements entirely. |
 
 Each of these CSS declarations will be copied to appropriate element's attribute.
 


### PR DESCRIPTION
Update the README to note that fact that data-premailer="ignore" also applies to 'link' tags.
